### PR TITLE
Add simple web UI and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,27 @@ python benachmark.py daten.csv
 Das Skript versucht, anhand der Herstellerteilenummer und des Herstellers Preise im Internet zu finden und vergleicht diese mit dem eigenen Preis.
 
 Bitte beachten: In dieser Beispielimplementierung werden die Suchergebnisse über DuckDuckGo abgefragt. Ohne Internetverbindung liefert das Skript keine Treffer.
+
+## Weboberfläche
+
+Ein kleines Web UI auf Basis von React und TypeScript befindet sich im Verzeichnis `frontend`. Die zugehörige API wird mit FastAPI bereitgestellt.
+
+### Starten der API
+
+Die API erwartet die Umgebungsvariablen `SUPABASE_URL` und `SUPABASE_KEY` um Daten in Supabase zu speichern. Anschließend kann die API mit uvicorn gestartet werden:
+
+```bash
+uvicorn api.main:app --reload
+```
+
+### Starten des Frontends
+
+Im `frontend` Verzeichnis befinden sich eine minimale Vite-Konfiguration. Nach der Installation der Node-Abhängigkeiten kann das UI im Entwicklungsmodus gestartet werden:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Die Anwendung bietet ein Formular zum Upload von Hersteller und Teilenummer. Nach dem Absenden werden die Daten an die API gesendet, in Supabase gespeichert und der Preisvergleich als Hintergrundaufgabe gestartet.

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI, BackgroundTasks
+from pydantic import BaseModel
+import os
+from supabase import create_client, Client
+
+from benachmark import compare_prices
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_KEY")
+
+supabase: Client | None = None
+if SUPABASE_URL and SUPABASE_KEY:
+    supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+app = FastAPI()
+
+class Part(BaseModel):
+    manufacturer: str
+    part_number: str
+
+
+def store_part(part: Part):
+    if not supabase:
+        return
+    supabase.table("parts").insert({
+        "manufacturer": part.manufacturer,
+        "part_number": part.part_number,
+    }).execute()
+    # price comparison and store results
+    comparison = compare_prices({
+        "Hersteller": part.manufacturer,
+        "Herstellerteilenummer": part.part_number,
+    })
+    supabase.table("comparisons").insert({
+        "manufacturer": comparison["manufacturer"],
+        "part_number": comparison["part_number"],
+        "our_price": comparison.get("our_price"),
+        "difference": comparison.get("difference"),
+    }).execute()
+
+@app.post("/upload")
+async def upload(part: Part, background_tasks: BackgroundTasks):
+    background_tasks.add_task(store_part, part)
+    return {"status": "accepted"}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "benachmark-web",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^4.0.0",
+    "vite": "^4.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Benachmark</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+
+export default function App() {
+  const [manufacturer, setManufacturer] = useState('');
+  const [partNumber, setPartNumber] = useState('');
+  const [message, setMessage] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage('');
+    try {
+      const res = await fetch('/upload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ manufacturer, part_number: partNumber })
+      });
+      const data = await res.json();
+      setMessage(data.status);
+    } catch (err) {
+      setMessage('Fehler beim Upload');
+    }
+  };
+
+  return (
+    <div>
+      <h1>Benachmark Upload</h1>
+      <form onSubmit={submit}>
+        <input
+          placeholder="Hersteller"
+          value={manufacturer}
+          onChange={(e) => setManufacturer(e.target.value)}
+        />
+        <input
+          placeholder="Teilenummer"
+          value={partNumber}
+          onChange={(e) => setPartNumber(e.target.value)}
+        />
+        <button type="submit">Upload</button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 pandas
 requests
 beautifulsoup4
+fastapi
+uvicorn
+supabase
+pydantic


### PR DESCRIPTION
## Summary
- implement FastAPI backend with Supabase integration
- add React/TypeScript frontend using Vite
- document how to run API and frontend
- update requirements with web dependencies

## Testing
- `python -m py_compile benachmark.py api/main.py`
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433e6402208332a55cdb977ddb46a4