### PR TITLE
Fix supabase auth calls for v2

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,19 +14,20 @@ export default function App() {
   const [rows, setRows] = useState<any[]>([]);
 
   useEffect(() => {
-    const session = supabase.auth.session();
-    setUser(session?.user ?? null);
-    const { data: listener } = supabase.auth.onAuthStateChange((_, session) => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setUser(session?.user ?? null);
+    });
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_, session) => {
       setUser(session?.user ?? null);
     });
     return () => {
-      listener?.subscription.unsubscribe();
+      subscription.unsubscribe();
     };
   }, []);
 
   const signIn = async (e: React.FormEvent) => {
     e.preventDefault();
-    await supabase.auth.signIn({ email, password });
+    await supabase.auth.signInWithPassword({ email, password });
   };
 
   const signOut = async () => {


### PR DESCRIPTION
## Summary
- use `getSession` to check existing session
- update sign-in to `signInWithPassword`

## Testing
- `yarn build` *(fails: package not in lockfile)*
- `yarn install` *(fails: 403 response)*

------
https://chatgpt.com/codex/tasks/task_e_684350c6dfa483329507493ed11273ad