### PR TITLE
Add signup functionality

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,11 @@ export default function App() {
     await supabase.auth.signInWithPassword({ email, password });
   };
 
+  const signUp = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await supabase.auth.signUp({ email, password });
+  };
+
   const signOut = async () => {
     await supabase.auth.signOut();
   };
@@ -69,6 +74,7 @@ export default function App() {
           onChange={e => setPassword(e.target.value)}
         />
         <button type="submit">Sign In</button>
+        <button type="button" onClick={signUp}>Sign Up</button>
       </form>
     );
   }


### PR DESCRIPTION
## Summary
- add signup handler using Supabase
- allow signing up via a button next to Sign In

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684351ab4cc8833294ac5d22453067c1