### PR TITLE
Add database setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,27 @@ Im eingeloggten Zustand stehen außerdem Beispiel-Dateien zum Download bereit. D
 4. `yarn dev`
 
 Die Seite ist anschließend unter `http://localhost:5173` erreichbar.
+
+## Database Setup
+
+Before running the app, execute the following SQL in your Supabase project:
+
+```sql
+create table file_uploads (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  path text not null,
+  filename text not null,
+  uploaded_at timestamptz not null default now()
+);
+alter table file_uploads enable row level security;
+create policy "allow user inserts" on file_uploads
+  for insert with check (auth.uid() = user_id);
+create policy "allow user read" on file_uploads
+  for select using (auth.uid() = user_id);
+```
+
+After creating the table, make sure to add a storage bucket named `uploads`
+in your Supabase project. The frontend expects the bucket name from the
+`VITE_STORAGE_BUCKET` environment variable.
+


### PR DESCRIPTION
## Summary
- update README with SQL snippet to set up `file_uploads` table and RLS
- mention creating the `uploads` storage bucket

## Testing
- `yarn build` *(fails: Proxy response (403) !== 200)*

------
https://chatgpt.com/codex/tasks/task_e_684405782e1c8332a77776966705576b