### PR TITLE
Fix Papa.parse usage

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,8 +92,8 @@ export default function App() {
     };
 
     if (file.name.endsWith('.csv')) {
-      Papa.parse<string[]>(file, {
-        complete: async result => {
+      Papa.parse(file, {
+        complete: async (result: Papa.ParseResult<string[]>) => {
           await afterValidation(result.data as any[][]);
         },
         skipEmptyLines: true,
@@ -114,7 +114,7 @@ export default function App() {
   const downloadXlsx = async () => {
     const response = await fetch('/sample.csv');
     const text = await response.text();
-    const { data } = Papa.parse<string[]>(text, { header: false });
+    const { data } = Papa.parse(text, { header: false }) as Papa.ParseResult<string[]>;
     const worksheet = XLSX.utils.aoa_to_sheet(data);
     const workbook = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(workbook, worksheet, 'Sheet1');


### PR DESCRIPTION
## Summary
- remove generics from Papa.parse calls so TypeScript doesn't complain

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6844095c9f288332b8c3cf1b82076e1d