### PR TITLE
Fix papaparse type error

### DIFF
--- a/frontend/src/types/papaparse.d.ts
+++ b/frontend/src/types/papaparse.d.ts
@@ -1,1 +1,39 @@
-declare module 'papaparse';
+declare module 'papaparse' {
+  export interface ParseError {
+    type: string;
+    code: string;
+    message: string;
+    row: number;
+  }
+
+  export interface ParseMeta {
+    delimiter: string;
+    linebreak: string;
+    aborted: boolean;
+    truncated: boolean;
+    cursor: number;
+    fields: string[];
+    typed: boolean;
+  }
+
+  export interface ParseResult<T> {
+    data: T[];
+    errors: ParseError[];
+    meta: ParseMeta;
+  }
+
+  export interface ParseConfig<T> {
+    complete?: (results: ParseResult<T>) => void | Promise<void>;
+    header?: boolean;
+    skipEmptyLines?: boolean | 'greedy';
+    delimiter?: string;
+  }
+
+  export function parse<T = any>(input: string | File, config?: ParseConfig<T>): ParseResult<T> | void;
+
+  const Papa: {
+    parse: typeof parse;
+  };
+
+  export default Papa;
+}


### PR DESCRIPTION
## Summary
- define the missing `ParseResult` type for `papaparse`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68440a6ef6608332ad32c20a67ab1b42