### PR TITLE
Fix TypeScript error with Papa.parse result

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -132,7 +132,7 @@ export default function App() {
   const downloadXlsx = async () => {
     const response = await fetch('/sample.csv');
     const text = await response.text();
-    const { data } = Papa.parse<string[]>(text, { header: false });
+    const { data } = Papa.parse<string[]>(text, { header: false }) as Papa.ParseResult<string[]>;
     const worksheet = XLSX.utils.aoa_to_sheet(data);
     const workbook = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(workbook, worksheet, 'Sheet1');


### PR DESCRIPTION
## Summary
- fix Papa.parse result typing with a type assertion

## Testing
- `yarn build` *(fails: Error when performing request to registry)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440c283dc0833296ef33d9d86ef133